### PR TITLE
fixed bug related to shank indexing when skipping channels.

### DIFF
--- a/Kilosort2Neurosuite.m
+++ b/Kilosort2Neurosuite.m
@@ -199,13 +199,16 @@ fprintf('\nComplete!')
         
         channel_order = {};
         indicesTokeep = {};
+        connected_index = zeros(size(rez.connected));
+        connected_index(rez.connected)=1:length(chanMapConn);
+        
         for i = 1:length(kcoords2)
             kcoords3 = kcoords2(i);
             waveforms_all{i} = zeros(sum(kcoords==kcoords3),ops.nt0,size(rez.ia{i},1));
             if exist('xml')
-                channel_order{i} = xml.AnatGrps(i).Channels+1;
+                channel_order = xml.AnatGrps(i).Channels+1;
                 ch_subset = find(kcoords==kcoords3);
-                [~,indicesTokeep{i},~] = intersect(channel_order{i},ch_subset);
+                [~,indicesTokeep{i},~] = intersect(connected_index(channel_order),ch_subset);
                 [~,indicesTokeep{i}] = sort(indicesTokeep{i});
             end
         end

--- a/createChannelMapFile_KSW.m
+++ b/createChannelMapFile_KSW.m
@@ -127,9 +127,13 @@ end
 connected = true(Nchannels, 1);
 
 % Removing dead channels by the skip parameter in the xml
+% order = [par.AnatGrps.Channels];
+% skip = find([par.AnatGrps.Skip]);
+% connected(order(skip)+1) = false;
+
 order = [par.AnatGrps.Channels];
-skip = find([par.AnatGrps.Skip]);
-connected(order(skip)+1) = false;
+skip2 = find(~ismember([par.AnatGrps.Channels], [par.SpkGrps.Channels])); % finds the indices of the channels that are not part of SpkGrps
+connected(order(skip2)+1) = false;
 
 chanMap     = 1:Nchannels;
 chanMap0ind = chanMap - 1;


### PR DESCRIPTION
fixed bug related to shank indexing when skipping channels.
Skipped channels are now defined by SpikeGroup and not the skip command (compatible with Klusters).